### PR TITLE
Screenshots

### DIFF
--- a/.config/openbox/rc.xml
+++ b/.config/openbox/rc.xml
@@ -453,27 +453,27 @@
         <command>bash -c '~/.scripts/shot-now'</command>
       </action>
     </keybind>
-     <keybind key="Print-S">
+     <keybind key="C-Print">
       <action name="Execute">
         <command>bash -c '~/.scripts/shot-now -C'</command>
       </action>
     </keybind>
-    <keybind key="Print-C">
+    <keybind key="S-Print">
       <action name="Execute">
         <command>bash -c '~/.scripts/shot-seldraw'</command>
       </action>
     </keybind>
-    <keybind key="Print-C-S">
+    <keybind key="S-C-Print">
       <action name="Execute">
         <command>bash -c '~/.scripts/shot-seldraw -C'</command>
       </action>
     </keybind>
-    <keybind key="Print-C-S-f">
+    <keybind key="S-C-f-Print">
       <action name="Execute">
         <command>bash -c '~/.scripts/shot-seldraw -C -F'</command>
       </action>
     </keybind>
-    <keybind key="Print-C-f">
+    <keybind key="S-f-Print">
       <action name="Execute">
         <command>bash -c '~/.scripts/shot-seldraw -F'</command>
       </action>

--- a/.config/openbox/rc.xml
+++ b/.config/openbox/rc.xml
@@ -125,9 +125,9 @@
   </resize>
   <!-- You can reserve a portion of your screen where windows will not cover when they are maximized, or when they are initially placed. Many programs reserve space automatically, but you can use this in other cases. -->
   <margins>
-    <top>10</top>
-    <bottom>10</bottom>
-    <left>55</left>
+    <top>0</top>
+    <bottom>0</bottom>
+    <left>0</left>
     <right>0</right>
   </margins>
   <dock>
@@ -231,7 +231,7 @@
     <keybind key="W-S-Left">
       <action name="MoveResizeTo">
         <x>0</x>
-        <y>-10</y>
+        <y>0</y>
         <width>1/2</width>
         <height>1/1</height>
       </action>
@@ -239,14 +239,14 @@
     <keybind key="W-S-Right">
       <action name="MoveResizeTo">
         <x>-0</x>
-        <y>-10</y>
+        <y>0</y>
         <width>1/2</width>
         <height>1/1</height>
       </action>
     </keybind>
     <keybind key="W-S-Up">
       <action name="MoveResizeTo">
-        <y>-10</y>
+        <y>0</y>
         <width>1/2</width>
         <height>1/2</height>
       </action>
@@ -260,8 +260,8 @@
     </keybind>
         <keybind key="W-S-space">
         <action name="MoveResizeTo">
-        <x>-10</x>
-        <y>-10</y>
+        <x>0</x>
+        <y>0</y>
         <width>1/1</width>
         <height>1/1</height>
   </action>

--- a/.config/openbox/rc.xml
+++ b/.config/openbox/rc.xml
@@ -26,13 +26,13 @@
     <!-- whether to place windows in the center of the free area found or the top left corner -->
     <monitor>Mouse</monitor>
     <!-- with Smart placement on a multi-monitor system, try to place new windows on: 'Any' - any monitor, 'Mouse' - where the mouse is, 'Active' - where the active window is, 'Primary' - only on the primary monitor -->
-    <primaryMonitor>1</primaryMonitor>
+    <primaryMonitor>1</primaryMonitor>1
     <!-- The monitor where Openbox should place popup dialogs such as the focus cycling popup, or the desktop switch popup. It can be an index from 1, specifying a particular monitor. Or it can be one of the following: 'Mouse' - where the mouse is, or
     'Active' - where the active window is -->
   </placement>
   <theme>
-    <name>Sweetly</name>
-    <titleLayout>CIML</titleLayout>
+    <name>Fleon</name>
+    <titleLayout>LIMC</titleLayout>
     <!-- available characters are NDSLIMC, each can occur at most once. N: window icon L: window label (AKA title). I: iconify M: maximize C: close S: shade (roll up/down) D: omnipresent (on all desktops). -->
     <keepBorder>yes</keepBorder>
     <animateIconify>no</animateIconify>
@@ -117,18 +117,18 @@
     <!-- 'Center', 'Top', or 'Fixed' -->
     <popupFixedPosition>
       <!-- these are used if popupPosition is set to 'Fixed' -->
-      <x>10</x>
+      <x>0</x>
       <!-- positive number for distance from left edge, negative number for distance from right edge, or 'Center' -->
-      <y>10</y>
+      <y>0</y>
       <!-- positive number for distance from top edge, negative number for distance from bottom edge, or 'Center' -->
     </popupFixedPosition>
   </resize>
   <!-- You can reserve a portion of your screen where windows will not cover when they are maximized, or when they are initially placed. Many programs reserve space automatically, but you can use this in other cases. -->
   <margins>
     <top>10</top>
-    <bottom>55</bottom>
-    <left>10</left>
-    <right>10</right>
+    <bottom>10</bottom>
+    <left>55</left>
+    <right>0</right>
   </margins>
   <dock>
     <position>Bottom</position>
@@ -231,7 +231,7 @@
     <keybind key="W-S-Left">
       <action name="MoveResizeTo">
         <x>0</x>
-        <y>0</y>
+        <y>-10</y>
         <width>1/2</width>
         <height>1/1</height>
       </action>
@@ -239,14 +239,14 @@
     <keybind key="W-S-Right">
       <action name="MoveResizeTo">
         <x>-0</x>
-        <y>0</y>
+        <y>-10</y>
         <width>1/2</width>
         <height>1/1</height>
       </action>
     </keybind>
     <keybind key="W-S-Up">
       <action name="MoveResizeTo">
-        <y>0</y>
+        <y>-10</y>
         <width>1/2</width>
         <height>1/2</height>
       </action>
@@ -258,6 +258,14 @@
         <height>1/2</height>
       </action>
     </keybind>
+        <keybind key="W-S-space">
+        <action name="MoveResizeTo">
+        <x>-10</x>
+        <y>-10</y>
+        <width>1/1</width>
+        <height>1/1</height>
+  </action>
+</keybind>
     <!-- desktop switching -->
     <keybind key="W-1">
       <action name="GoToDesktop">
@@ -443,6 +451,31 @@
     <keybind key="Print">
       <action name="Execute">
         <command>bash -c '~/.scripts/shot-now'</command>
+      </action>
+    </keybind>
+     <keybind key="Print-S">
+      <action name="Execute">
+        <command>bash -c '~/.scripts/shot-now -C'</command>
+      </action>
+    </keybind>
+    <keybind key="Print-C">
+      <action name="Execute">
+        <command>bash -c '~/.scripts/shot-seldraw'</command>
+      </action>
+    </keybind>
+    <keybind key="Print-C-S">
+      <action name="Execute">
+        <command>bash -c '~/.scripts/shot-seldraw -C'</command>
+      </action>
+    </keybind>
+    <keybind key="Print-C-S-f">
+      <action name="Execute">
+        <command>bash -c '~/.scripts/shot-seldraw -C -F'</command>
+      </action>
+    </keybind>
+    <keybind key="Print-C-f">
+      <action name="Execute">
+        <command>bash -c '~/.scripts/shot-seldraw -F'</command>
       </action>
     </keybind>
     <keybind key="W-Print">

--- a/.config/openbox/rc.xml
+++ b/.config/openbox/rc.xml
@@ -468,12 +468,12 @@
         <command>bash -c '~/.scripts/shot-seldraw -C'</command>
       </action>
     </keybind>
-    <keybind key="S-C-f-Print">
+    <keybind key="S-C-W-Print">
       <action name="Execute">
         <command>bash -c '~/.scripts/shot-seldraw -C -F'</command>
       </action>
     </keybind>
-    <keybind key="S-f-Print">
+    <keybind key="S-W-Print">
       <action name="Execute">
         <command>bash -c '~/.scripts/shot-seldraw -F'</command>
       </action>

--- a/.scripts/shot-now
+++ b/.scripts/shot-now
@@ -7,20 +7,26 @@ savedir=~/Pictures
 
 icon="~/.icons/gladient/shot.png"
 
+copy=0
+for flag in "$@"
+do
+  case $flag in
+     -C ) copy=1                                ;;
+  esac
+done
 # Begin
 rm /tmp/*_scrot*.png
 
-case $1 in
-    delay)
-    sleep .5s
-    ;;
-    *)
-    ;;
-esac
 
 scrot -e 'mv $f /tmp/'
-current="$(ls /tmp/ | grep 'scrot')"
-cp /tmp/$current $savedir
-rm /tmp/*_scrot*.png
+current="$(ls /tmp/ | grep 'scrot**.png')"
+mv /tmp/$current $savedir
+if [ $copy -eq 1 ]
+then
+    xclip -selection clipboard -t image/png -i $savedir/$current
+fi
 
 notify-send -i $icon -u low "Screenshot" "Saved in\n<u>$savedir/</u>"
+
+
+exit 0

--- a/.scripts/shot-seldraw
+++ b/.scripts/shot-seldraw
@@ -2,11 +2,22 @@
 
 # Select window or draw and add borders then show preview
 # See scrot manual
-
+echo "$@"
 savedir=~/Pictures
 bordercolor="#ffffff"
 
 icon="~/.icons/gladient/shot.png"
+framed=0
+copy=0
+for flag in "$@"
+do
+  case $flag in
+     -F ) framed=1                              ;;
+     -C ) copy=1                                ;;
+  esac
+done
+echo $framed
+echo $copy
 
 # Begin
 rm /tmp/*_scrot*.png
@@ -18,21 +29,33 @@ notify-send -t 750 -i $icon -u low "Screenshot" "Processing captured image"
 # Use imagemagick to add border
 current="$(ls /tmp/ | grep 'scrot' | awk -F'.png' '{print $1}')"
 
-convert /tmp/$current.png \( +clone -background black -shadow 30x10+0+0 \) \
-+swap -background none -layers merge +repage /tmp/$current-shadow.png
+if [ $framed -eq 1 ]
+then
+    convert /tmp/$current.png \( +clone -background black -shadow 30x10+0+0 \) \
+    +swap -background none -layers merge +repage /tmp/$current-shadow.png
 
-convert /tmp/$current-shadow.png -bordercolor $bordercolor \
--border 5 $savedir/$current-framed.png
+    convert /tmp/$current-shadow.png -bordercolor $bordercolor \
+    -border 5 $savedir/$current-framed.png
+fi
+# Moving original file
+mv /tmp/$current.png $savedir
 
-# Copy original file
-cp /tmp/$current.png $savedir
-
-rm /tmp/*_scrot*.png
+if [ $copy -eq 1 ]
+then
+    if [ $framed -eq 1 ]
+    then
+        xclip -selection clipboard -t image/png -i $savedir/$current-framed.png
+    else
+        xclip -selection clipboard -t image/png -i $savedir/$current.png
+    fi
+fi
 
 # Checking final file
 [[ -f $savedir/$current-framed.png ]] && \
+[[ -f $savedir/$current.png ]] && \
 
-notify-send -i $icon -u low "Screenshot" "Saved in\n<u>$savedir/</u>" && \
+notify-send -i $icon -u low "Screenshot" "Saved in\n<u>$savedir/$current.png</u>" && \
 
 # Open final result
-viewnior $savedir/$current-framed.png &> /dev/null
+#viewnior $savedir/$current-framed.png &> /dev/null
+exit 0

--- a/.scripts/shot-timer
+++ b/.scripts/shot-timer
@@ -7,6 +7,13 @@ savedir=~/Pictures
 sec="5"
 
 icon="~/.icons/gladient/shot.png"
+copy=0
+for flag in "$@"
+do
+  case $flag in
+     -C ) copy=1                                ;;
+  esac
+done
 
 # Begin
 notify-send -t 1000 -i $icon -u low "Screenshot" "In $(echo $sec)s .."
@@ -14,7 +21,11 @@ notify-send -t 1000 -i $icon -u low "Screenshot" "In $(echo $sec)s .."
 rm /tmp/*_scrot*.png
 scrot -d $sec -e 'mv $f /tmp/'
 current="$(ls /tmp/ | grep 'scrot')"
-cp /tmp/$current $savedir
-rm /tmp/*_scrot*.png
+mv /tmp/$current $savedir
+if [ $copy -eq 1 ]
+then
+    xclip -selection clipboard -t image/png -i $savedir/$current
+fi
 
 notify-send -i $icon -u low "Screenshot" "Saved in\n<u>$savedir/</u>"
+exit 0


### PR DESCRIPTION
# Changelog
Added -C (Clipboard) flag for shot-seldraw, shot-now, shot-timer, this flag copy image to clipboard and you can paste it.
Added -F (Framed) flag for shot-seldeaw, this flag add border to image
Added options for copying or saving for screenshot.sh
Added new shortcuts: 
     PrintScreen - screenshots all dispalys and saves it
     Super+PrintScreen - starts screenshot.sh menu
     Ctrl+PrintScreen - screenshots all dispalys and copies it to clipboard
     Shift+PrintScreen - screenshots selected area and saves it
     Shift+Ctrl+PrintScreen - screenshot selected area and copies it to clipboard
     Shift+Super(Windows)+PrintScreen - screenshots selected area, adds border and saves
     Shift+Ctrl+Super(Windows)+PrintScreen - screenshots selected area, adds border and copies it to clipboard
     Shift+Super(Windows)+Space - open window to full screen