### PR TITLE
run pulseaudio from openbox autostart

### DIFF
--- a/.config/openbox/autostart
+++ b/.config/openbox/autostart
@@ -27,6 +27,9 @@ lxpolkit &
 ls="$(cat ~/.config/openbox/lockscreen)"
 xautolock -time 3 -locker "$ls" -detectsleep &
 
+# PulseAudio
+pulseaudio --start --log-target=syslog
+
 # Others (e.g: mpd)
 mpd &> /dev/null
 bash -c '~/.ncmpcpp/scripts/track-change-detector' &


### PR DESCRIPTION
Several apps (ex: `chromium`, `google-chrome-stable`) have no sound. The sound only heard after play MPD or Spotify because PulseAudio is not running from startup.