### PR TITLE
removing pulseaudio from configs

### DIFF
--- a/.config/openbox/autostart
+++ b/.config/openbox/autostart
@@ -6,8 +6,7 @@
 # ---
 source $HOME/.owl4ce_var
 
-# Start pulseaudio if not started automatically
-pulseaudio --start --log-target=syslog &
+# there was once a pulseaudio here
 
 # UI Appearance
 bash -c "$VISMOD_DIR/mode-toggle startup"


### PR DESCRIPTION
Hi, I ran into this problem: Pulseaudio and pavucontrol just didn't work at system startup. I tried different ways, went to forums and so on. and i managed to solve the problem by simply removing pulseaudio autostart from the openbox configs.
the problem occurred on various computers, so the crookedness of my hands is excluded, i hope this will be fixed: >